### PR TITLE
Fix MSB4018 by disabling static asset compression

### DIFF
--- a/CaotinhoAuMiau.csproj
+++ b/CaotinhoAuMiau.csproj
@@ -4,6 +4,10 @@
     <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+    <!-- Desativa a compressão automática dos assets estáticos durante o build
+         para evitar conflitos de arquivos duplicados. A tarefa
+         ApplyCompressionNegotiation lançava erro devido a chaves repetidas -->
+    <DisableBuildCompression>true</DisableBuildCompression>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- disable StaticWebAssets compression to avoid ApplyCompressionNegotiation conflicts

## Testing
- `dotnet restore` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_6876cb09a8288325bdbcea27235b868d