### PR TITLE
Definir base path exclusivo para assets

### DIFF
--- a/CaotinhoAuMiau.csproj
+++ b/CaotinhoAuMiau.csproj
@@ -8,6 +8,10 @@
          para evitar conflitos de arquivos duplicados. A tarefa
          ApplyCompressionNegotiation lançava erro devido a chaves repetidas -->
     <DisableBuildCompression>true</DisableBuildCompression>
+    <!-- Define um caminho base único para os assets estáticos gerados.
+         Sem essa configuração o MSBuild tenta mesclar arquivos de diretórios
+         diferentes com o mesmo nome, resultando no erro de "Conflicting assets" -->
+    <StaticWebAssetBasePath>_content/CaotinhoAuMiau2</StaticWebAssetBasePath>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- ajustar `CaotinhoAuMiau.csproj` para usar `StaticWebAssetBasePath` e evitar conflitos de arquivos estáticos

## Testing
- `dotnet build` *(falhou: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_6876e500553083258867bc2576681b33