### PR TITLE
Remove 'Voltar ao Site' from admin sidebar

### DIFF
--- a/Views/Shared/_SlidebarAdmin.cshtml
+++ b/Views/Shared/_SlidebarAdmin.cshtml
@@ -143,11 +143,8 @@
         padding-bottom: 20px;
     }
     
-    .link-home, .link-sair {
-        margin-top: 5px;
-    }
-    
     .link-sair {
+        margin-top: 5px;
         color: #ff6b6b;
     }
     
@@ -276,13 +273,6 @@
     
     
     <div class="links-rodape">
-        <a href="@Url.Action("Index", "Home")" class="link-nav link-home">
-            <span class="circulo-icone">
-                <i class="fas fa-home"></i>
-            </span>
-            <span>Voltar ao Site</span>
-        </a>
-        
         <a href="/usuario/logout" class="link-nav link-sair">
             <span class="circulo-icone">
                 <i class="fas fa-sign-out-alt"></i>

--- a/wwwroot/css/admin/slidebar-admin.css
+++ b/wwwroot/css/admin/slidebar-admin.css
@@ -349,21 +349,9 @@
 }
 
 
-.link-nav.link-home, .link-nav.link-sair {
-    margin-top: 0.5rem;
-}
-
-.link-nav.link-home {
-    background-color: rgba(255, 255, 255, 0.1);
-    margin-top: auto;
-    margin-bottom: 0.5rem;
-}
-
-.link-nav.link-home:hover {
-    background-color: rgba(255, 255, 255, 0.2);
-}
 
 .link-nav.link-sair {
+    margin-top: 0.5rem;
     color: #ffffff;
     background-color: rgba(220, 53, 69, 0.2);
 }


### PR DESCRIPTION
## Summary
- delete "Voltar ao Site" link from admin sidebar
- clean related CSS rules

## Testing
- `dotnet build -v q`
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_6877203b4b9c8325a2c5426cb6dfbb04