### PR TITLE
Corrige carregamento dos gráficos no painel

### DIFF
--- a/Views/Admin/GerenciamentoDashboard.cshtml
+++ b/Views/Admin/GerenciamentoDashboard.cshtml
@@ -21,6 +21,13 @@
     <link rel="stylesheet" href="~/lib/bootstrap/dist/css/bootstrap.min.css" />
     <link rel="stylesheet" href="~/lib/fontawesome/css/all.min.css" />
     <script src="~/lib/chart.js/chart.umd.min.js"></script>
+    <script>
+        if (typeof Chart === 'undefined') {
+            var fallback = document.createElement('script');
+            fallback.src = 'https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js';
+            document.head.appendChild(fallback);
+        }
+    </script>
     <link rel="stylesheet" href="~/css/admin/admin-dashboard.css" asp-append-version="true" />
     <style>
         


### PR DESCRIPTION
## Resumo
- garante que o Chart.js seja carregado mesmo se a pasta `wwwroot/lib/chart.js` estiver vazia

## Testes
- `npm install`

------
https://chatgpt.com/codex/tasks/task_e_68785e49b2648325866610ce6862ba04