### PR TITLE
Atualiza Font Awesome para 6.7.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,9 +4,27 @@
   "requires": true,
   "packages": {
     "": {
+      "hasInstallScript": true,
       "dependencies": {
-        "@popperjs/core": "^2.11.8"
+        "@fortawesome/fontawesome-free": "^6.7.2",
+        "@popperjs/core": "^2.11.8",
+        "chart.js": "^4.4.1"
       }
+    },
+    "node_modules/@fortawesome/fontawesome-free": {
+      "version": "6.7.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-6.7.2.tgz",
+      "integrity": "sha512-JUOtgFW6k9u4Y+xeIaEiLr3+cjoUPiAuLXoyKOJSia6Duzb7pq+A76P9ZdPDoAoxHdHzq6gE9/jKBGXlZT8FbA==",
+      "license": "(CC-BY-4.0 AND OFL-1.1 AND MIT)",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@kurkle/color": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
+      "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
+      "license": "MIT"
     },
     "node_modules/@popperjs/core": {
       "version": "2.11.8",
@@ -16,6 +34,18 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
+      }
+    },
+    "node_modules/chart.js": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.0.tgz",
+      "integrity": "sha512-aYeC/jDgSEx8SHWZvANYMioYMZ2KX02W6f6uVfyteuCGcadDLcYVHdfdygsTQkQ4TKn5lghoojAsPj5pu0SnvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@kurkle/color": "^0.3.0"
+      },
+      "engines": {
+        "pnpm": ">=8"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   },
   "dependencies": {
     "@popperjs/core": "^2.11.8",
-    "@fortawesome/fontawesome-free": "^6.4.0",
+    "@fortawesome/fontawesome-free": "^6.7.2",
     "chart.js": "^4.4.1"
   }
 }


### PR DESCRIPTION
## Resumo
- atualiza a dependência `@fortawesome/fontawesome-free` para a versão `^6.7.2`
- atualiza o arquivo `package-lock.json`

## Testes
- `npm install --no-audit --progress=false`
- `dotnet build --no-restore` *(falhou: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6879935218208325bcc07314623d4220